### PR TITLE
When a NoSuchWindow exception occurs we now close the RPC client & the webdriver nicely

### DIFF
--- a/YoutubeMusicDiscordRichPresenceCSharp/Program.cs
+++ b/YoutubeMusicDiscordRichPresenceCSharp/Program.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics;
-using System.Net.Mime;
 using OpenQA.Selenium;
 using YoutubeMusicDiscordRichPresenceCSharp.Browser;
 using YtmRcpLib.Rpc;

--- a/YoutubeMusicDiscordRichPresenceCSharp/Program.cs
+++ b/YoutubeMusicDiscordRichPresenceCSharp/Program.cs
@@ -1,4 +1,6 @@
 ﻿using System.Diagnostics;
+using System.Net.Mime;
+using OpenQA.Selenium;
 using YoutubeMusicDiscordRichPresenceCSharp.Browser;
 using YtmRcpLib.Rpc;
 
@@ -54,18 +56,27 @@ internal class Program
 
         while (!_shouldQuit)
         {
-            var playingInfo = retriever.FromBrowser(browserHandler);
-
-            if (playingInfo is not null)
+            try
             {
-                RpcHandler.SetPresence(SongPresenceHandler.GetSongPresence(retriever, playingInfo));
-            }
-            else
-            {
-                Console.WriteLine("Couldn't find song, thus no rpc set.");
-            }
+                var playingInfo = retriever.FromBrowser(browserHandler);
 
-            Thread.Sleep(refreshInterval);
+                if (playingInfo is not null)
+                {
+                    RpcHandler.SetPresence(SongPresenceHandler.GetSongPresence(retriever, playingInfo));
+                }
+                else
+                {
+                    Console.WriteLine("Couldn't find song, thus no rpc set.");
+                }
+
+                Thread.Sleep(refreshInterval);
+            }
+            catch (NoSuchWindowException ex)
+            {
+                Console.Out.WriteLine("Looks like the browser window we were hooked too was closed. Disconnected.");
+                _shouldQuit = true;
+                Deinitialize();
+            }
         }
     }
 
@@ -112,5 +123,6 @@ internal class Program
         RpcHandler.Deinitialize();
         BrowserHandler.Close();
         Console.WriteLine("Deinitialized.");
+        Environment.Exit(0);
     }
 }


### PR DESCRIPTION
All the new code you should care about:

```cs
catch (NoSuchWindowException ex)
{
    Console.Out.WriteLine("Looks like the browser window we were hooked too was closed. Disconnected.");
    _shouldQuit = true;
    Deinitialize();
}
```